### PR TITLE
Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
           distribution: 'adopt'
       - name: Build with Gradle
         run: |
-          ./gradlew shadowJar -p bukkittest
           ./gradlew shadowJar -p bukkit
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on: [push, workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: 17
+          distribution: 'adopt'
+      - name: Build with Gradle
+        run: |
+          ./gradlew shadowJar -p lighteco-bukkittest
+          ./gradlew shadowJar -p lighteco-bukkit
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Built Jars
+          path: |
+            ./build/libs/*.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         run: |
           ./gradlew shadowJar -p bukkittest
           ./gradlew shadowJar -p bukkit
+          ./gradlew shadowJar -p currency-money
       - uses: actions/upload-artifact@v3
         with:
           name: Built Jars

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
           distribution: 'adopt'
       - name: Build with Gradle
         run: |
-          ./gradlew shadowJar -p lighteco-bukkittest
-          ./gradlew shadowJar -p lighteco-bukkit
+          ./gradlew shadowJar -p bukkittest
+          ./gradlew shadowJar -p bukkit
       - uses: actions/upload-artifact@v3
         with:
           name: Built Jars

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
           distribution: 'adopt'
       - name: Build with Gradle
         run: |
+          ./gradlew shadowJar -p bukkittest
           ./gradlew shadowJar -p bukkit
       - uses: actions/upload-artifact@v3
         with:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,5 +17,6 @@ pluginManagement {
         mavenLocal()
         mavenCentral()
         gradlePluginPortal()
+        maven("https://repo.jopga.me/releases")
     }
 }


### PR DESCRIPTION
This creates a GitHub actions workflow to build "lighteco-bukkit" and "lighteco-bukkittest" then publish the built jars as an artifact. I have tested it locally with [act](https://github.com/nektos/act) but it will currently fail on a GitHub runner due to [serverloaded](https://github.com/xHyroM/lighteco/blob/9c8e459ca8b172e948793c7653147c78c7af5ece/bukkittest/build.gradle.kts#L5) not being available. 